### PR TITLE
Fix broken geometries for full products

### DIFF
--- a/src/stactools/goes/commands.py
+++ b/src/stactools/goes/commands.py
@@ -18,7 +18,7 @@ def create_goes_command(cli):
                   "--cogify",
                   is_flag=True,
                   help="Convert the netcdf to two COGs")
-    @click.option("--tight-geometry/--no-tight-geometry", default=True)
+    @click.option("--tight-geometry/--no-tight-geometry", default=False)
     def create_item(href, destination, cogify, tight_geometry):
         """Creates a STAC item from a GOES netcdf file.
 

--- a/src/stactools/goes/dataset.py
+++ b/src/stactools/goes/dataset.py
@@ -23,7 +23,7 @@ class Dataset:
     """A GOES dataset."""
     def __init__(self,
                  href: str,
-                 tight_geometry: bool = True,
+                 tight_geometry: bool = False,
                  read_href_modifier: Optional[ReadHrefModifier] = None):
         """Creates a new dataset from a netcdf href."""
         # Projection stuff built with help from

--- a/src/stactools/goes/stac.py
+++ b/src/stactools/goes/stac.py
@@ -11,7 +11,7 @@ from stactools.goes import Dataset
 def create_item(href: str,
                 read_href_modifier: Optional[ReadHrefModifier] = None,
                 cog_directory: Optional[str] = None,
-                tight_geometry: bool = True) -> Item:
+                tight_geometry: bool = False) -> Item:
     """Creates a pystac.Item from a GOES netcdf file."""
     if read_href_modifier:
         href = read_href_modifier(href)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,21 @@
 from stactools.testing import TestData
 
 CMIP_FILE_NAME = "OR_ABI-L2-CMIPM1-M6C02_G16_s20211231619248_e20211231619306_c20211231619382.nc"
+CMIP_FULL_FILE_NAME = "OR_ABI-L2-CMIPF-M6C02_G16_s20210201540193_e20210201549501_c20210201549575.nc"
 MCMIP_FILE_NAME = "OR_ABI-L2-MCMIPM1-M6_G16_s20211451800267_e20211451800324_c20211451800407.nc"
 EXTERNAL_DATA = {
     CMIP_FILE_NAME: {
         "url":
         ("https://noaa-goes16.s3.amazonaws.com/ABI-L2-CMIPM/2021/123/16"
          "/OR_ABI-L2-CMIPM1-M6C02_G16_s20211231619248_e20211231619306_c20211231619382.nc"
+         ),
+        "compress":
+        "none"
+    },
+    CMIP_FULL_FILE_NAME: {
+        "url":
+        ("https://noaa-goes16.s3.amazonaws.com/ABI-L2-CMIPF"
+         "/2021/020/15/OR_ABI-L2-CMIPF-M6C02_G16_s20210201540193_e20210201549501_c20210201549575.nc"
          ),
         "compress":
         "none"

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,13 +1,15 @@
 import dateutil
+import math
 import os.path
 from tempfile import TemporaryDirectory
 import unittest
 
+from shapely.geometry import shape
 from pystac import MediaType
 from pystac.extensions.projection import ProjectionExtension
 
 from stactools.goes import stac, __version__
-from tests import test_data, CMIP_FILE_NAME
+from tests import test_data, CMIP_FILE_NAME, CMIP_FULL_FILE_NAME
 
 
 class CreateItemTest(unittest.TestCase):
@@ -83,3 +85,11 @@ class CreateItemTest(unittest.TestCase):
         )
         item = stac.create_item(path)
         item.validate()
+
+    def test_full_product_geometry(self):
+        # https://github.com/stactools-packages/goes/issues/4
+        path = test_data.get_external_data(CMIP_FULL_FILE_NAME)
+        item = stac.create_item(path)
+        geometry = shape(item.geometry)
+        self.assertFalse(math.isnan(geometry.area),
+                         f"This geometry has a NaN area: {geometry}")


### PR DESCRIPTION
The `tight_geometry` option broke for full disc scans, because their native coordinate system extents didn't reproject to EPSG:4326 well.