### PR TITLE
feat: raise error for missing extent

### DIFF
--- a/src/stactools/goes/dataset.py
+++ b/src/stactools/goes/dataset.py
@@ -11,7 +11,7 @@ from shapely.geometry import mapping, Polygon, box, shape
 from stactools.core.projection import reproject_geom
 from stactools.goes.attributes import GlobalAttributes
 from stactools.goes.enums import ImageType
-from stactools.goes.errors import GOESInvalidGeometryError
+from stactools.goes.errors import GOESInvalidGeometryError, GOESMissingExtentError
 from stactools.goes.file_name import ABIL2FileName
 
 GOES_ELLIPSOID = CustomEllipsoid.from_name("GRS80")
@@ -74,6 +74,10 @@ class DatasetGeometry:
         ymin = extent.attrs["geospatial_southbound_latitude"][0].item()
         xmax = extent.attrs["geospatial_eastbound_longitude"][0].item()
         ymax = extent.attrs["geospatial_northbound_latitude"][0].item()
+
+        if all(v == -999.0 for v in (xmin, ymin, xmax, ymax)):
+            raise GOESMissingExtentError(
+                "All four geospatial extents are -999.0 (missing)")
 
         # If xmin is -999.0, clip as -180
         # This happens when the left side of the shot

--- a/src/stactools/goes/errors.py
+++ b/src/stactools/goes/errors.py
@@ -24,3 +24,7 @@ class GOESInvalidGeometryError(Exception):
     E.g. a coordinate is a fill value (-999.0)
     """
     pass
+
+
+class GOESMissingExtentError(Exception):
+    """Raised when all four bounds are missing (-999) in the netcdf"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,6 +59,9 @@ PC_RRQPE_F = (
 )
 PC_SST_F = (
     "OR_ABI-L2-SSTF-M6_G17_s20193550800326_e20193550859393_c20193550904140.nc")
+INVALID_LAT_LNG = (
+    "OR_ABI-L2-MCMIPM2-M6_G17_s20212742248555_e20212742248555_c20212742249339.nc"
+)
 
 EXTERNAL_DATA = {
     CMIP_FILE_NAME: {
@@ -233,6 +236,15 @@ EXTERNAL_DATA = {
         ("https://goeseuwest.blob.core.windows.net/noaa-goes17/"
          "ABI-L2-SSTF/2019/355/08/"
          "OR_ABI-L2-SSTF-M6_G17_s20193550800326_e20193550859393_c20193550904140.nc"
+         ),
+        "planetary_computer":
+        True
+    },
+    INVALID_LAT_LNG: {
+        "url":
+        ("https://goeseuwest.blob.core.windows.net/noaa-goes17/"
+         "ABI-L2-MCMIPM/2021/274/22/"
+         "OR_ABI-L2-MCMIPM2-M6_G17_s20212742248555_e20212742248555_c20212742249339.nc"
          ),
         "planetary_computer":
         True

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -14,13 +14,13 @@ from pystac.extensions.projection import ProjectionExtension
 from pystac.extensions.eo import EOExtension
 
 from stactools.goes import stac, __version__
-from stactools.goes.errors import GOESRProductHrefsError
+from stactools.goes.errors import GOESRProductHrefsError, GOESMissingExtentError
 from stactools.goes.stac import ProductHrefs
 from stactools.goes.enums import ProductAcronym
 from stactools.goes.file_name import ABIL2FileName
-from tests import (EXTERNAL_DATA, PC_FDC_C, PC_LST_M, PC_MCMIP_C, PC_MCMIP_F,
-                   PC_MCMIP_F_17, test_data, CMIP_FILE_NAME,
-                   CMIP_FULL_FILE_NAME, MCMIP_FILE_NAME)
+from tests import (EXTERNAL_DATA, INVALID_LAT_LNG, PC_FDC_C, PC_LST_M,
+                   PC_MCMIP_C, PC_MCMIP_F, PC_MCMIP_F_17, test_data,
+                   CMIP_FILE_NAME, CMIP_FULL_FILE_NAME, MCMIP_FILE_NAME)
 
 US_CENTER = shape({
     "type":
@@ -211,6 +211,11 @@ class CreateItemFromHrefTest(unittest.TestCase):
             # Assert geometry is valid
             g = shape(item.geometry)
             self.assertTrue(g.is_valid)
+
+    def test_invalid_lat_lng(self):
+        path = test_data.get_external_data(INVALID_LAT_LNG)
+        with self.assertRaises(GOESMissingExtentError):
+            stac.create_item_from_href(path)
 
 
 class CreateItemTest(unittest.TestCase):


### PR DESCRIPTION
Some files -999.0 (missing) for all four geospatial extent fields. This commit adds a specific error for that case that can be caught downstream.