### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## [v0.1.6] - 2021-10-06
+## [Unreleased]
+
+## [0.1.7] - 2023-01-06
+
+### Added
+
+- GOES-18 support ([#32](https://github.com/stactools-packages/goes/pull/32))
+
+### Updated
+
+- Linting and documentation ([#26](https://github.com/stactools-packages/goes/pull/26))
+
+### Fixed
+
+- Packaging metadata ([#24](https://github.com/stactools-packages/goes/pull/24))
+
+## [0.1.6] - 2021-10-06
 
 If not specified, changes were part of [#21](https://github.com/stactools-packages/goes/pull/21).
 
@@ -26,7 +42,7 @@ If not specified, changes were part of [#21](https://github.com/stactools-packag
 - Projection if the xmin value is -999.0 for extreme western shots
 - Specific exception is raised if all projection extent values are missing ([#22](https://github.com/stactools-packages/goes/pull/22)])
 
-## [v0.1.5] - 2021-09-13
+## [0.1.5] - 2021-09-13
 
 ### Changed
 
@@ -38,13 +54,13 @@ If not specified, changes were part of [#21](https://github.com/stactools-packag
 - Avoid errors when `long_description` is not set ([#19](https://github.com/stactools-packages/goes/pull/19))
 - Close hdfpy File to ensure proper cleanup ([#19](https://github.com/stactools-packages/goes/pull/19))
 
-## [v0.1.4] - 2021-09-07
+## [0.1.4] - 2021-09-07
 
 ### Changed
 
 - Don't add `eo:bands` to DQF files in MCMIP products ([#17](https://github.com/stactools-packages/goes/pull/17))
 
-## [v0.1.3] - 2021-09-07
+## [0.1.3] - 2021-09-07
 
 ### Added
 
@@ -54,21 +70,20 @@ If not specified, changes were part of [#21](https://github.com/stactools-packag
 
 - Re-added stderr/stdout to cogify ([#15](https://github.com/stactools-packages/goes/pull/15))
 
-
-## [v0.1.2] - 2021-09-07
+## [0.1.2] - 2021-09-07
 
 ### Added
 
 - EO extension for MCMIP items ([#11](https://github.com/stactools-packages/goes/pull/11))
 - Raise an error when COGification fails ([#13](https://github.com/stactools-packages/goes/pull/13))
 
-## [v0.1.1] - 2021-09-02
+## [0.1.1] - 2021-09-02
 
 ### Added
 
 - More descriptive titles for COG assets ([#9](https://github.com/stactools-packages/goes/pull/9))
 
-## [v0.1.0] - 2021-07-29
+## [0.1.0] - 2021-07-29
 
 Initial release.
 
@@ -87,3 +102,13 @@ Initial release.
 ### Fixed
 
 - Nothing.
+
+[Unreleased]: <https://github.com/stactools-packages/goes/compare/v0.1.7...main>
+[0.1.7]: <https://github.com/stactools-packages/goes/compare/v0.1.6...v0.1.7>
+[0.1.6]: <https://github.com/stactools-packages/goes/compare/v0.1.5...v0.1.6>
+[0.1.5]: <https://github.com/stactools-packages/goes/compare/v0.1.4...v0.1.5>
+[0.1.4]: <https://github.com/stactools-packages/goes/compare/v0.1.3...v0.1.4>
+[0.1.3]: <https://github.com/stactools-packages/goes/compare/v0.1.2...v0.1.3>
+[0.1.2]: <https://github.com/stactools-packages/goes/compare/v0.1.1...v0.1.2>
+[0.1.1]: <https://github.com/stactools-packages/goes/compare/v0.1.0...v0.1.1>
+[0.1.0]: <https://github.com/stactools-packages/goes/releases/tag/v0.1.0>

--- a/examples/OR_ABI-L2-F-M6_G16_s20210201540193/OR_ABI-L2-F-M6_G16_s20210201540193.json
+++ b/examples/OR_ABI-L2-F-M6_G16_s20210201540193/OR_ABI-L2-F-M6_G16_s20210201540193.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "FULL DISK",

--- a/examples/OR_ABI-L2-M1-M6_G16_s20211231619248/OR_ABI-L2-M1-M6_G16_s20211231619248.json
+++ b/examples/OR_ABI-L2-M1-M6_G16_s20211231619248/OR_ABI-L2-M1-M6_G16_s20211231619248.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/examples/OR_ABI-L2-M1-M6_G16_s20211451800267/OR_ABI-L2-M1-M6_G16_s20211451800267.json
+++ b/examples/OR_ABI-L2-M1-M6_G16_s20211451800267/OR_ABI-L2-M1-M6_G16_s20211451800267.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/examples/OR_ABI-L2-M1-M6_G16_s20211451810267/OR_ABI-L2-M1-M6_G16_s20211451810267.json
+++ b/examples/OR_ABI-L2-M1-M6_G16_s20211451810267/OR_ABI-L2-M1-M6_G16_s20211451810267.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/examples/OR_ABI-L2-M1-M6_G16_s20211451811238/OR_ABI-L2-M1-M6_G16_s20211451811238.json
+++ b/examples/OR_ABI-L2-M1-M6_G16_s20211451811238/OR_ABI-L2-M1-M6_G16_s20211451811238.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/examples/OR_ABI-L2-M1-M6_G16_s20211451816238/OR_ABI-L2-M1-M6_G16_s20211451816238.json
+++ b/examples/OR_ABI-L2-M1-M6_G16_s20211451816238/OR_ABI-L2-M1-M6_G16_s20211451816238.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/examples/OR_ABI-L2-M1-M6_G17_s20200111504255/OR_ABI-L2-M1-M6_G17_s20200111504255.json
+++ b/examples/OR_ABI-L2-M1-M6_G17_s20200111504255/OR_ABI-L2-M1-M6_G17_s20200111504255.json
@@ -8,7 +8,7 @@
       "ABI"
     ],
     "processing:software": {
-      "stactools-goes": "0.1.6"
+      "stactools-goes": "0.1.7"
     },
     "goes:system-environment": "OR",
     "goes:image-type": "MESOSCALE",

--- a/src/stactools/goes/__init__.py
+++ b/src/stactools/goes/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 """Library version"""
 
 import stactools.core


### PR DESCRIPTION
- Closes #33 

Includes some CHANGELOG fixups. Test release was successful: https://test.pypi.org/project/stactools-goes/0.1.7/.